### PR TITLE
モデル・テーブルの作成

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,0 +1,2 @@
+class Movie < ApplicationRecord
+end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,0 +1,2 @@
+class Text < ApplicationRecord
+end

--- a/db/migrate/20210611140340_create_texts.rb
+++ b/db/migrate/20210611140340_create_texts.rb
@@ -1,0 +1,11 @@
+class CreateTexts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :texts do |t|
+      t.integer :genre, null: false, default: 0
+      t.string :title, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210611141048_create_movies.rb
+++ b/db/migrate/20210611141048_create_movies.rb
@@ -1,0 +1,11 @@
+class CreateMovies < ActiveRecord::Migration[6.1]
+  def change
+    create_table :movies do |t|
+      t.integer :genre, null: false, default: 0
+      t.string :title, null: false
+      t.string :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_11_140340) do
+ActiveRecord::Schema.define(version: 2021_06_11_141048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "movies", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.string "url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_06_11_140340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "texts", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end


### PR DESCRIPTION
close #4

## 実装内容

- `Text` モデルと `texts` テーブルを作成
  - カラムは `genre（integer型）` `title（string型）` `content（text型）`
  - 全てのカラムに `NOT NULL` 制約を設定
  - `genre` カラムのデフォルト値は `0`

 - `Movie` モデルと `movies` テーブルを作成
   - カラムは `genre（integer型）` `title（string型）` `url（string型）`
   - 全てのカラムに `NOT NULL` 制約を設定
   - `genre` カラムのデフォルト値は `0`

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考

ルーティングが空のため `rubocop -a` 実行時に `offense` が出ましたが、そのままコミットいたしました。