### PR TITLE
Feature/#9 import teaching materials csv

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,8 @@
+# texts, movies テーブルを再生成（関連付くテーブルを含む）
+%w[texts movies].each do |table_name|
+  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
+end
+
 email = "test@example.com"
 password = "password"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,11 +9,13 @@ require "csv"
 CSV.foreach("db/csv_data/text_data.csv", headers: true) do |row|
   Text.create!(row.to_h)
 end
+puts "テキスト教材のCSVインポートに成功しました。"
 
 # 動画教材のCSVを読み込む
 CSV.foreach("db/csv_data/movie_data.csv", headers: true) do |row|
   Movie.create!(row.to_h)
 end
+puts "動画教材のCSVインポートに成功しました。"
 
 email = "test@example.com"
 password = "password"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,13 @@
   ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
 end
 
+require "csv"
+
+# テキスト教材のCSVをを読み込み
+CSV.foreach("db/csv_data/text_data.csv", headers: true) do |row|
+  Text.create!(row.to_h)
+end
+
 email = "test@example.com"
 password = "password"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,14 @@ end
 
 require "csv"
 
-# テキスト教材のCSVをを読み込み
+# テキスト教材のCSVを読み込む
 CSV.foreach("db/csv_data/text_data.csv", headers: true) do |row|
   Text.create!(row.to_h)
+end
+
+# 動画教材のCSVを読み込む
+CSV.foreach("db/csv_data/movie_data.csv", headers: true) do |row|
+  Movie.create!(row.to_h)
 end
 
 email = "test@example.com"


### PR DESCRIPTION
close #9 

## 実装内容

- `db/seeds.rb`の最初に以下を追加<br>
```
# texts, movies テーブルを再生成（関連付くテーブルを含む）
%w[texts movies].each do |table_name|
  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
end
```

- `db/seeds.rb`に、テキスト教材のCSVを読み込み、`texts`テーブルにデータを投入する処理を追加
- `db/seeds.rb`に、動画教材のCSVを読み込み、`movies`テーブルにデータを投入する処理を追加

## 参考資料
-  [【やんばるエキスパート教材】CSVインポート](https://www.yanbaru-code.com/texts/217)
- [【Rails】rake seedコマンドでCSVファイルからDBに読み込ませる方法](https://qiita.com/mmmasuke/items/545afaf5876d3dc52670)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
