### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,0 +1,20 @@
+.card-box {
+  margin: 0 auto;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+.content-card {
+  height: 370px;
+  max-width: 376px;
+  margin: 0 auto;
+}
+
+.img-fluid {
+  max-width: 100%;
+  height: auto;
+}
+
+.card-title {
+  margin-top: 1rem;
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,7 @@
 class TextsController < ApplicationController
-  def index; end
+  def index
+    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+  end
 
   def show; end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -13,4 +13,6 @@ class Text < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -4,7 +4,7 @@
       <img class="img-fluid" alt="<%= text.title %>" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" loading="lazy">
     </div>
     <div class="card-body">
-      <a href="#" class="btn btn-primary">読破済みにする</a>
+      <button type="button" class="btn btn-secondary btn-lg btn-block">読破済みにする</button>
       <p class="card-title mt-3"><%= text.title %></p>
       <p>【<%= text.genre %>】</p>
     </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,10 +1,12 @@
-<div class="card" style="width: 18rem;">
-  <div class="card-header p-0">
-    <img class="img-fluid" alt="<%= text.title %>" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" loading="lazy">
-  </div>
-  <div class="card-body">
-    <a href="#" class="btn btn-primary">読破済みにする</a>
-    <p class="card-title"><%= text.title %></p>
-    <p class="card-text">【<%= text.genre %>】</p>
+<div class="card-box col-12 col-md-6 col-lg-4">
+  <div class="card content-card border-dark mb-3">
+    <div class="card-header p-0">
+      <img class="img-fluid" alt="<%= text.title %>" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" loading="lazy">
+    </div>
+    <div class="card-body">
+      <a href="#" class="btn btn-primary">読破済みにする</a>
+      <p class="card-title mt-3"><%= text.title %></p>
+      <p>【<%= text.genre %>】</p>
+    </div>
   </div>
 </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,0 +1,8 @@
+<div class="card" style="width: 18rem;">
+  <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+  <div class="card-body">
+    <a href="#" class="btn btn-primary">読破済みにする</a>
+    <p class="card-title"><%= text.title %></p>
+    <p class="card-text">【<%= text.genre %>】</p>
+  </div>
+</div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,5 +1,7 @@
 <div class="card" style="width: 18rem;">
-  <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+  <div class="card-header p-0">
+    <img class="img-fluid" alt="<%= text.title %>" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" loading="lazy">
+  </div>
   <div class="card-body">
     <a href="#" class="btn btn-primary">読破済みにする</a>
     <p class="card-title"><%= text.title %></p>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -6,7 +6,7 @@
     <div class="card-body">
       <button type="button" class="btn btn-secondary btn-lg btn-block">読破済みにする</button>
       <p class="card-title mt-3"><%= text.title %></p>
-      <p>【<%= text.genre %>】</p>
+      <p>【<%= text.genre_i18n %>】</p>
     </div>
   </div>
 </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,0 +1,9 @@
+<div class="container">
+  <h1 class="text-center mt-2 mb-4">
+    Ruby/Rails <br class="d-sm-none">
+    テキスト教材
+  </h1>
+  <div class="row">
+    <%= render partial: "text", collection: @texts %>
+  </div>
+</div>


### PR DESCRIPTION
close #14 

## 実装内容

- `app/models/text.rb` に `RAILS_GENRE_LIST = %w[basic git ruby rails]` を定義
- Railsテキスト教材の一覧ページを作成
  - 表示するジャンルは `Text::RAILS_GENRE_LIST` に制限
  - Bootstrap の `Cards` や `Grid System` を用いてスタイルを設定
  - 画像部分はデフォルト画像を表示  

## 参考資料

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
