### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,7 @@
+.content {
+  height: 400px;
+}
+
+.movie-title {
+  margin-top: 2rem;
+}

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,4 +1,4 @@
-.content {
+.content-card {
   height: 400px;
 }
 

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -13,4 +13,5 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,11 @@
+<div class="card-box clo-12 col-md-6 col-lg-4">
+  <div class="card content border-dark mb-3">
+    <div class="embed-responsive embed-responsive-16by9">
+      <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+    </div>
+    <div class="card-body">
+      <button type="button" class="btn btn-secondary btn-lg btn-block">読破済みにする</button>
+      <p class="movie-title"><%= "Lv.#{movie_counter + 1}：#{movie.title}" %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,5 +1,5 @@
 <div class="card-box clo-12 col-md-6 col-lg-4">
-  <div class="card content border-dark mb-3">
+  <div class="card content-card border-dark mb-3">
     <div class="embed-responsive embed-responsive-16by9">
       <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
     </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,1 +1,8 @@
-
+<div class="container">
+  <h1 class="text-center mt-2 mb-4">
+    Ruby/Rails 動画
+  </h1>
+  <div class="row">
+    <%= render @movies %>
+  </div>
+</div>


### PR DESCRIPTION
close #16

## 実装内容
- Rails動画教材一覧ページの実装
  - `app/models/movie.rb` に RAILS_GENRE_LIST = %w[basic git ruby rails] を定義
  - ジャンルを RAILS_GENRE_LIST を用いて制限
  - 動画タイトル毎にLvを表示
  - `Bootstrap` の `Cards` や `Grid System` を用いてスタイルを設定
    - カードの高さを揃える
    - 動画とタイトルのスペースの修正は`movies.scss`で調整

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行