### PR TITLE
#22 テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.genre_select(params[:genre])
   end
 
   def show

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -15,4 +15,13 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
+
+  def self.genre_select(genre)
+    if genre == "php"
+      where(genre: PHP_GENRE_LIST)
+    else
+      where(genre: RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,7 +1,6 @@
 <div class="container">
   <h1 class="text-center mt-2 mb-4">
-    Ruby/Rails <br class="d-sm-none">
-    テキスト教材
+    <%= page_title %> テキスト教材
   </h1>
   <div class="row">
     <%= render partial: "text", collection: @texts %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,10 +1,10 @@
-const { environment } = require('@rails/webpacker')
-const webpack = require('webpack')
+const { environment } = require("@rails/webpacker");
+const webpack = require("webpack");
 environment.plugins.append(
-  'Provide',
+  "Provide",
   new webpack.ProvidePlugin({
-    $: 'jquery',
-    jQuery: 'jquery',
+    $: "jquery",
+    jQuery: "jquery",
   })
-)
-module.exports = environment
+);
+module.exports = environment;

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,10 +1,10 @@
-const { environment } = require("@rails/webpacker");
-const webpack = require("webpack");
+const { environment } = require('@rails/webpacker')
+const webpack = require('webpack')
 environment.plugins.append(
-  "Provide",
+  'Provide',
   new webpack.ProvidePlugin({
-    $: "jquery",
-    jQuery: "jquery",
+    $: 'jquery',
+    jQuery: 'jquery',
   })
-);
-module.exports = environment;
+)
+module.exports = environment


### PR DESCRIPTION
close #22

## 実装内容

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
- それぞれのテキスト教材ページのタイトルが、「Ruby/Rails テキスト教材」もしくは「PHPテキスト教材」となるようにする
  - `app/helpers/application_helper.rb`の`page_title`を利用


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 補足
- 「webpackerのインストールを取り消し」以降のコミットについて
このプルリクの直前にもプルリクを行っていたのですが、その時にエラー解決のために`webpacker`を再インストールしました。以下、その際のプルリクです。（`webpacker`はエラーには関係ありませんでした）
https://github.com/yanbaru-expert/team_project_53/pull/45
プルリクを送ってすぐに、チーム開発でパッケージのバージョンを勝手に変更してはいけないと思い、直前のコミットに戻り再度プッシュを行おうと思いましたが上手くいかず、二度目のプルリク送信となってしまいました。
ややこしくしてしまい申し訳ございません。ご確認よろしくお願いいたします。
