### PR TITLE
#24  テキスト教材の読破済み機能

### DIFF
--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,11 @@
 class ReadProgressesController < ApplicationController
   def create
+    @text = Text.find(params[:text_id])
     current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
   end
 
   def destroy
+    @text = Text.find(params[:text_id])
     current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
   end
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,4 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,4 +1,9 @@
 class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
+
+  validates :user_id, uniqueness: {
+    scope: :text_id,
+    message: "は同じテキスト教材を２回以上読破済みにはできません"
+  }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,6 @@
 class Text < ApplicationRecord
+  has_many :read_progresses, dependent: :destroy
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,6 @@
 class Text < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
+  has_many :read_progressed_users, through: :read_progresses, source: :user
 
   with_options presence: true do
     validates :genre

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -18,4 +18,8 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  def read_progressed_by?(user)
+    read_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :read_progresses, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
+  has_many :read_progressed_texts, through: :read_progresses, source: :text
 
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/read_progress", text: @text) %>'

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/unread_progress", text: @text) %>'

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-lg btn-block", method: :delete %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :delete %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :delete, remote: true %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :delete, remote: true %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-lg btn-block", method: :delete %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :delete %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :delete, remote: true %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -5,12 +5,13 @@
         <img class="img-fluid" alt="<%= text.title %>" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" loading="lazy">
       </div>
       <div class="card-body">
-        <%# <button type="button" class="btn btn-secondary btn-lg btn-block">読破済みにする</button> %>
+        <p id="text-<%= text.id %>">
         <% if text.read_progressed_by?(current_user) %>
           <%= render "read_progress", text: text %>
         <% else %>
           <%= render "unread_progress", text: text %>
         <% end %>
+        </p>
         <p class="card-title mt-3"><%= text.title %></p>
         <p>【<%= text.genre_i18n %>】</p>
       </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -5,7 +5,12 @@
         <img class="img-fluid" alt="<%= text.title %>" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" loading="lazy">
       </div>
       <div class="card-body">
-        <button type="button" class="btn btn-secondary btn-lg btn-block">読破済みにする</button>
+        <%# <button type="button" class="btn btn-secondary btn-lg btn-block">読破済みにする</button> %>
+        <% if text.read_progressed_by?(current_user) %>
+          <%= render "read_progress", text: text %>
+        <% else %>
+          <%= render "unread_progress", text: text %>
+        <% end %>
         <p class="card-title mt-3"><%= text.title %></p>
         <p>【<%= text.genre_i18n %>】</p>
       </div>

--- a/app/views/texts/_unread_progress.html.erb
+++ b/app/views/texts/_unread_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :post %></button>

--- a/app/views/texts/_unread_progress.html.erb
+++ b/app/views/texts/_unread_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :post %></button>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :post, remote: true %></button>

--- a/app/views/texts/_unread_progress.html.erb
+++ b/app/views/texts/_unread_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary btn-block", method: :post, remote: true %></button>
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary btn-block", method: :post, remote: true %></button>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,3 +15,6 @@ ja:
         genre: ジャンル
         title: タイトル
         url: URL
+      read_progress:
+        user: ユーザー
+        text: テキスト教材

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
   root "texts#index"
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_progresses, only: [:create, :destroy]
+  end
   resources :movies, only: [:index]
 end

--- a/db/migrate/20210731014231_create_read_progresses.rb
+++ b/db/migrate/20210731014231_create_read_progresses.rb
@@ -1,0 +1,10 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210731014231_create_read_progresses.rb
+++ b/db/migrate/20210731014231_create_read_progresses.rb
@@ -6,5 +6,6 @@ class CreateReadProgresses < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+    add_index :read_progresses, [:user_id, :text_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_09_103234) do
+ActiveRecord::Schema.define(version: 2021_07_31_014231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_07_09_103234) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema.define(version: 2021_07_09_103234) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
close #24

## 実装内容

- 読破済み機能に使用する`ReadProgress`モデルを作成
  - 外部キー設定を行い，ユニーク制約を入れてからマイグレーション
  - バリデーションをモデルに追加
  - 各モデルの関連付け

- テキスト教材一覧ページに読破済み機能を実装
  - 読破済み機能の非同期処理化

## 参考資料（必要があれば）

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行