### PR TITLE
動画教材の読破済み機能

### DIFF
--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,0 +1,11 @@
+class WatchProgressesController < ApplicationController
+  def create
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.create!(movie_id: params[:movie_id])
+  end
+
+  def destroy
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.find_by(movie_id: params[:movie_id]).destroy!
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -20,7 +20,7 @@ class Movie < ApplicationRecord
   PHP_GENRE_LIST = %w[php].freeze
 
   def watch_progressed_by?(user)
-    watch_progresses.exists?(user_id: user.id)
+    watch_progresses.where(user_id: user.id)
   end
 
   def self.genre_select(genre)

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -19,6 +19,10 @@ class Movie < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
   PHP_GENRE_LIST = %w[php].freeze
 
+  def watch_progressed_by?(user)
+    watch_progresses.exists?(user_id: user.id)
+  end
+
   def self.genre_select(genre)
     if genre == "php"
       where(genre: PHP_GENRE_LIST)

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,7 @@
 class Movie < ApplicationRecord
+  has_many :watch_progresses, dependent: :destroy
+  has_many :watch_progresses_users, through: :watch_progresses, source: :user
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -20,14 +20,14 @@ class Movie < ApplicationRecord
   PHP_GENRE_LIST = %w[php].freeze
 
   def watch_progressed_by?(user)
-    watch_progresses.where(user_id: user.id)
+    watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
   end
 
   def self.genre_select(genre)
     if genre == "php"
-      where(genre: PHP_GENRE_LIST)
+      where(genre: PHP_GENRE_LIST).includes(:watch_progresses)
     else
-      where(genre: RAILS_GENRE_LIST)
+      where(genre: RAILS_GENRE_LIST).includes(:watch_progresses)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
   has_many :read_progressed_texts, through: :read_progresses, source: :text
+  has_many :watch_progresses, dependent: :destroy
+  has_many :watch_progresses_texts, through: :watch_progresses, source: :text
 
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
   has_many :read_progressed_texts, through: :read_progresses, source: :text
   has_many :watch_progresses, dependent: :destroy
-  has_many :watch_progresses_texts, through: :watch_progresses, source: :text
+  has_many :watch_progresses_movies, through: :watch_progresses, source: :movie
 
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -4,6 +4,6 @@ class WatchProgress < ApplicationRecord
 
   validates :user_id, uniqueness: {
     scope: :movie_id,
-    message: "は同じ動画教材を２回以上読破済みにはできません"
+    message: "は同じ動画教材を２回以上視聴済みにはできません"
   }
 end

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,2 +1,6 @@
 class WatchProgress < ApplicationRecord
+  validates :user_id, uniqueness: {
+    scope: :movie_id,
+    message: "は同じ動画教材を２回以上読破済みにはできません"
+  }
 end

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,0 +1,2 @@
+class WatchProgress < ApplicationRecord
+end

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,4 +1,7 @@
 class WatchProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+
   validates :user_id, uniqueness: {
     scope: :movie_id,
     message: "は同じ動画教材を２回以上読破済みにはできません"

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -4,7 +4,13 @@
       <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
     </div>
     <div class="card-body">
-      <button type="button" class="btn btn-secondary btn-lg btn-block">読破済みにする</button>
+      <p id="movie-<%= movie.id %>">
+        <% if movie.watch_progressed_by?(current_user) %>
+          <%= render "watch_progress", movie: movie %>
+        <% else %>
+          <%= render "unwatch_progress", movie: movie %>
+        <% end %>
+      </p>
       <p class="movie-title"><%= "Lv.#{movie_counter + @movies.offset_value + 1}：#{movie.title}" %></p>
     </div>
   </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -6,9 +6,9 @@
     <div class="card-body">
       <p id="movie-<%= movie.id %>">
         <% if movie.watch_progressed_by?(current_user) %>
-          <%= render "watch_progress", movie: movie %>
-        <% else %>
           <%= render "unwatch_progress", movie: movie %>
+        <% else %>
+          <%= render "watch_progress", movie: movie %>
         <% end %>
       </p>
       <p class="movie-title"><%= "Lv.#{movie_counter + @movies.offset_value + 1}：#{movie.title}" %></p>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -6,9 +6,9 @@
     <div class="card-body">
       <p id="movie-<%= movie.id %>">
         <% if movie.watch_progressed_by?(current_user) %>
-          <%= render "unwatch_progress", movie: movie %>
-        <% else %>
           <%= render "watch_progress", movie: movie %>
+        <% else %>
+          <%= render "unwatch_progress", movie: movie %>
         <% end %>
       </p>
       <p class="movie-title"><%= "Lv.#{movie_counter + @movies.offset_value + 1}：#{movie.title}" %></p>

--- a/app/views/movies/_unwatch_progress.html.erb
+++ b/app/views/movies/_unwatch_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みにする", movie_watch_progresses_path(movie), class: "btn btn-secondary btn-block", method: :post, remote: true %></button>

--- a/app/views/movies/_watch_progress.html.erb
+++ b/app/views/movies/_watch_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みを解除", movie_watch_progresses_path(movie), class: "btn btn-primary btn-block", method: :delete, remote: true %>

--- a/app/views/watch_progresses/create.js.erb
+++ b/app/views/watch_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/watch_progress", movie: @movie) %>'

--- a/app/views/watch_progresses/destroy.js.erb
+++ b/app/views/watch_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/unwatch_progress", movie: @movie) %>'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,6 @@ ja:
       read_progress:
         user: ユーザー
         text: テキスト教材
+      watch_progress:
+        user: ユーザー
+        movie: 動画教材

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
   resources :texts, only: [:index, :show] do
     resource :read_progresses, only: [:create, :destroy]
   end
-  resources :movies, only: [:index]
+  resources :movies, only: [:index] do
+    resource :watch_progresses, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20210803142729_create_watch_progresses.rb
+++ b/db/migrate/20210803142729_create_watch_progresses.rb
@@ -1,0 +1,11 @@
+class CreateWatchProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :watch_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :watch_progresses, [:user_id, :movie_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_31_014231) do
+ActiveRecord::Schema.define(version: 2021_08_03_142729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,18 @@ ActiveRecord::Schema.define(version: 2021_07_31_014231) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "watch_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["movie_id"], name: "index_watch_progresses_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watch_progresses_on_user_id_and_movie_id", unique: true
+    t.index ["user_id"], name: "index_watch_progresses_on_user_id"
+  end
+
   add_foreign_key "read_progresses", "texts"
   add_foreign_key "read_progresses", "users"
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close #25 

## 実装内容

- 視聴済み機能に使用する `WatchProgress` モデルを作成
  - `User` モデル，`Movie` モデルと関連付け
  - `user_id`, `movie_id` の組にユニーク制約を入れる

- 動画教材一覧ページに非同期処理の視聴済み機能を実装

## 参考資料（必要があれば）

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
